### PR TITLE
Add proper pluralization for time units

### DIFF
--- a/src/components/TimeDisplay/TimeDisplay.test.tsx
+++ b/src/components/TimeDisplay/TimeDisplay.test.tsx
@@ -70,4 +70,36 @@ describe("TimeDisplay", () => {
     });
     expect(dayElem?.textContent).toBe("4");
   });
+
+  it("Uses proper pluralization (singular)", async () => {
+    const streamStartTime = DateTime.now().plus({ days: 1, hours: 1, minutes: 1, seconds: 2 }).toISO(); // Offset all units by 1, except seconds
+    render(<TimeDisplay streamStartTime={streamStartTime} />);
+    const dayNoun = document.getElementById("dayNoun");
+    const hourNoun = document.getElementById("hourNoun");
+    const minuteNoun = document.getElementById("minuteNoun");
+    const secondNoun = document.getElementById("secondNoun");
+    act(() => {
+      jest.advanceTimersByTime(1000); // Advance the timer by 1 second (makes the component update and use pluralize function)
+    });
+    expect(dayNoun?.textContent).toBe("Day");
+    expect(hourNoun?.textContent).toBe("Hour");
+    expect(minuteNoun?.textContent).toBe("Minute");
+    expect(secondNoun?.textContent).toBe("Second");
+  });
+
+  it("Uses proper pluralization (plural)", async () => {
+    const streamStartTime = DateTime.now().plus({ days: 2, hours: 2, minutes: 2, seconds: 3 }).toISO(); // Offset all units by 2, except seconds
+    render(<TimeDisplay streamStartTime={streamStartTime} />);
+    const dayNoun = document.getElementById("dayNoun");
+    const hourNoun = document.getElementById("hourNoun");
+    const minuteNoun = document.getElementById("minuteNoun");
+    const secondNoun = document.getElementById("secondNoun");
+    act(() => {
+      jest.advanceTimersByTime(1000); // Advance the timer by 1 second (makes the component update and use pluralize function)
+    });
+    expect(dayNoun?.textContent).toBe("Days");
+    expect(hourNoun?.textContent).toBe("Hours");
+    expect(minuteNoun?.textContent).toBe("Minutes");
+    expect(secondNoun?.textContent).toBe("Seconds");
+  });
 });

--- a/src/components/TimeDisplay/TimeDisplay.tsx
+++ b/src/components/TimeDisplay/TimeDisplay.tsx
@@ -96,28 +96,28 @@ export class TimeDisplay extends React.Component<
             <h2 className="text-3xl" id="dayCountNumber">
               {this.state.daysUntil}
             </h2>
-            <h3 className="text-xs uppercase">{pluralize(this.state.daysUntil, "Day", "Days")}</h3>
+            <h3 className="text-xs uppercase" id="dayNoun">{pluralize(this.state.daysUntil, "Day", "Days")}</h3>
           </div>
           <span className="self-center px-2 text-5xl">·</span>
           <div className="flex flex-col">
             <h2 className="text-3xl" id="hourCountNumber">
               {this.state.hoursUntil}
             </h2>
-            <h3 className="text-xs uppercase">{pluralize(this.state.hoursUntil, "Hour", "Hours")}</h3>
+            <h3 className="text-xs uppercase" id="hourNoun">{pluralize(this.state.hoursUntil, "Hour", "Hours")}</h3>
           </div>
           <span className="self-center px-2 text-5xl">·</span>
           <div className="flex flex-col">
             <h2 className="text-3xl" id="minuteCountNumber">
               {this.state.minutesUntil}
             </h2>
-            <h3 className="text-xs uppercase">{pluralize(this.state.minutesUntil, "Minute", "Minutes")}</h3>
+            <h3 className="text-xs uppercase" id="minuteNoun">{pluralize(this.state.minutesUntil, "Minute", "Minutes")}</h3>
           </div>
           <span className="self-center px-2 text-5xl">·</span>
           <div className="flex flex-col">
             <h2 className="text-3xl" id="secondCountNumber">
               {this.state.secondsUntil}
             </h2>
-            <h3 className="text-xs uppercase">{pluralize(this.state.secondsUntil, "Second", "Seconds")}</h3>
+            <h3 className="text-xs uppercase" id="secondNoun">{pluralize(this.state.secondsUntil, "Second", "Seconds")}</h3>
           </div>
         </>
       );

--- a/src/components/TimeDisplay/TimeDisplay.tsx
+++ b/src/components/TimeDisplay/TimeDisplay.tsx
@@ -14,6 +14,13 @@ type TimeDisplayState = {
   countdownFinished: boolean;
 };
 
+function pluralize(value: number, singular: string, plural: string): string {
+  if(value === 1) {
+    return singular;
+  }
+  return plural;
+}
+
 export class TimeDisplay extends React.Component<
   TimeDisplayProps,
   TimeDisplayState
@@ -89,28 +96,28 @@ export class TimeDisplay extends React.Component<
             <h2 className="text-3xl" id="dayCountNumber">
               {this.state.daysUntil}
             </h2>
-            <h3 className="text-xs uppercase">Days</h3>
+            <h3 className="text-xs uppercase">{pluralize(this.state.daysUntil, "Day", "Days")}</h3>
           </div>
           <span className="self-center px-2 text-5xl">·</span>
           <div className="flex flex-col">
             <h2 className="text-3xl" id="hourCountNumber">
               {this.state.hoursUntil}
             </h2>
-            <h3 className="text-xs uppercase">Hours</h3>
+            <h3 className="text-xs uppercase">{pluralize(this.state.hoursUntil, "Hour", "Hours")}</h3>
           </div>
           <span className="self-center px-2 text-5xl">·</span>
           <div className="flex flex-col">
             <h2 className="text-3xl" id="minuteCountNumber">
               {this.state.minutesUntil}
             </h2>
-            <h3 className="text-xs uppercase">Minutes</h3>
+            <h3 className="text-xs uppercase">{pluralize(this.state.minutesUntil, "Minute", "Minutes")}</h3>
           </div>
           <span className="self-center px-2 text-5xl">·</span>
           <div className="flex flex-col">
             <h2 className="text-3xl" id="secondCountNumber">
               {this.state.secondsUntil}
             </h2>
-            <h3 className="text-xs uppercase">Seconds</h3>
+            <h3 className="text-xs uppercase">{pluralize(this.state.secondsUntil, "Second", "Seconds")}</h3>
           </div>
         </>
       );


### PR DESCRIPTION
Use a singular noun i.e. (Day, Hour, Minute, Second) when appropriate.